### PR TITLE
Add accessors to internals

### DIFF
--- a/include/hashinator/hashinator.h
+++ b/include/hashinator/hashinator.h
@@ -1724,6 +1724,7 @@ private:
          i++;
       }
       assert(false && "Hashmap completely overflown");
+      return false;
    }
 
 public:

--- a/include/hashinator/hashinator.h
+++ b/include/hashinator/hashinator.h
@@ -463,6 +463,28 @@ public:
       }
    }
 
+   // Dangerous methods for exposing internals
+   template <bool warn = true>
+   HASHINATOR_HOSTDEVICE MapInfo* expose_mapinfo() noexcept {
+      if constexpr(warn) {
+         printf("Warning, exposing Hashmap internal info struct!\n");
+      }
+      return _mapInfo;
+   }
+   template <bool warn = true>
+   HASHINATOR_HOSTDEVICE hash_pair<KEY_TYPE, VAL_TYPE>* expose_bucketdata() noexcept {
+      if constexpr(warn) {
+         printf("Warning, exposing Hashmap internal bucket data!\n");
+      }
+      return buckets.data();
+   }
+   HASHINATOR_HOSTDEVICE inline KEY_TYPE expose_emptybucket() const noexcept {
+      return EMPTYBUCKET;
+   }
+   HASHINATOR_HOSTDEVICE inline KEY_TYPE expose_tombstone() const noexcept {
+      return TOMBSTONE;
+   }
+
 #ifdef HASHINATOR_CPU_ONLY_MODE
    void clear() {
       buckets = split::SplitVector<hash_pair<KEY_TYPE, VAL_TYPE>>(1 << _mapInfo->sizePower, {EMPTYBUCKET, VAL_TYPE()});

--- a/include/splitvector/gpu_wrappers.h
+++ b/include/splitvector/gpu_wrappers.h
@@ -116,6 +116,60 @@ __device__ __forceinline__ T s_atomicSub(T* address, U val) noexcept {
       } else {
          return atomicSub((unsigned int*)address, static_cast<T>(val));
       }
+   } else if constexpr (sizeof(T) == 8) {
+      return atomicAdd((unsigned long long*)address, static_cast<T>(-val));
+   } else {
+      // Cannot be static_assert(false...);
+      static_assert(!sizeof(T*), "Not supported");
+   }
+}
+
+/**
+ * @brief Wrapper for atomic maximum operation.
+ *
+ * @tparam T The data type of the value being maximized.
+ * @tparam U The data type of the value to maximize against.
+ * @param address Pointer to the memory location.
+ * @param val The value to maximize against.
+ * @return The original value at the memory location.
+ */
+template <typename T, typename U>
+__device__ __forceinline__ T s_atomicMax(T* address, U val) noexcept {
+   static_assert(std::is_integral<T>::value && "Only integers supported");
+   if constexpr (sizeof(T) == 4) {
+      if constexpr (std::is_signed<T>::value) {
+         return atomicMax((int*)address, static_cast<T>(val));
+      } else {
+         return atomicMax((unsigned int*)address, static_cast<T>(val));
+      }
+   } else if constexpr (sizeof(T) == 8) {
+      return atomicMax((unsigned long long*)address, static_cast<T>(val));
+   } else {
+      // Cannot be static_assert(false...);
+      static_assert(!sizeof(T*), "Not supported");
+   }
+}
+
+/**
+ * @brief Wrapper for atomic minimum operation.
+ *
+ * @tparam T The data type of the value being minimized.
+ * @tparam U The data type of the value to minimize against.
+ * @param address Pointer to the memory location.
+ * @param val The value to minimize against.
+ * @return The original value at the memory location.
+ */
+template <typename T, typename U>
+__device__ __forceinline__ T s_atomicMin(T* address, U val) noexcept {
+   static_assert(std::is_integral<T>::value && "Only integers supported");
+   if constexpr (sizeof(T) == 4) {
+      if constexpr (std::is_signed<T>::value) {
+         return atomicMin((int*)address, static_cast<T>(val));
+      } else {
+         return atomicMin((unsigned int*)address, static_cast<T>(val));
+      }
+   } else if constexpr (sizeof(T) == 8) {
+      return atomicMin((unsigned long long*)address, static_cast<T>(val));
    } else {
       // Cannot be static_assert(false...);
       static_assert(!sizeof(T*), "Not supported");

--- a/unit_tests/stream_compaction/unit.cu
+++ b/unit_tests/stream_compaction/unit.cu
@@ -6,8 +6,8 @@
 #include <gtest/gtest.h>
 #include "../../include/splitvector/splitvec.h"
 #include "../../include/splitvector/split_tools.h"
-#include "include/common.h"
-#include "include/splitvector/archMacros.h"
+#include "../../include/common.h"
+#include "../../include/splitvector/archMacros.h"
 #define expect_true EXPECT_TRUE
 #define expect_false EXPECT_FALSE
 #define expect_eq EXPECT_EQ


### PR DESCRIPTION
Used for creating batch kernels which can with one launch operate on umpteen different hash maps. Pass the kernel a pointer to the hashmap itself, and it can then act upon the contents in a limited fashion (such as doing a bulk reset)